### PR TITLE
Add compatibility with shopware/production:bin/watch-administration.sh

### DIFF
--- a/src/Resources/app/administration/src/main.js
+++ b/src/Resources/app/administration/src/main.js
@@ -1,9 +1,9 @@
 import { Component, Application } from 'src/core/shopware';
-import './components/multisafepay-refund'
-import './components/multisafepay-verify-api-key'
-import './components/multisafepay-support'
-import template from './extension/sw-order-detail/sw-order-detail.html.twig'
-import MultiSafepayApiService from './service/MultiSafepayApi.service'
+import './components/multisafepay-refund';
+import './components/multisafepay-verify-api-key';
+import './components/multisafepay-support';
+import template from './extension/sw-order-detail/sw-order-detail.html.twig';
+import MultiSafepayApiService from './service/MultiSafepayApi.service';
 
 
 Component.override('sw-order-detail-base', {

--- a/src/Resources/app/administration/src/main.js
+++ b/src/Resources/app/administration/src/main.js
@@ -4,7 +4,8 @@ import './components/multisafepay-verify-api-key';
 import './components/multisafepay-support';
 import template from './extension/sw-order-detail/sw-order-detail.html.twig';
 import MultiSafepayApiService from './service/MultiSafepayApi.service';
-
+import localeDE from './snippets/de_DE.json';
+import localeEN from './snippets/en_GB.json';
 
 Component.override('sw-order-detail-base', {
     template
@@ -15,7 +16,5 @@ Application.addServiceProvider('multiSafepayApiService', (container) => {
     return new MultiSafepayApiService(initContainer.httpClient, container.loginService);
 });
 
-import localeDE from './snippets/de_DE.json';
-import localeEN from './snippets/en_GB.json';
 Shopware.Locale.extend('de-DE', localeDE);
 Shopware.Locale.extend('en-GB', localeEN);


### PR DESCRIPTION
When you have an active installation of MultiSafepay and want to run bin/watch-administration.sh within a shopware/production setup you can't get the javascript compiled as it will give you the following errors:

```
ERROR in vendor/multisafepay/shopware6/src/Resources/app/administration/src/main.js
Module Error (from ./node_modules/eslint-loader/index.js):

  ✘  http://eslint.org/docs/rules/semi                    Missing semicolon                                                            
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:2:42
  
  ✘  http://eslint.org/docs/rules/semi                    Missing semicolon                                                            
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:3:50
  
  ✘  http://eslint.org/docs/rules/semi                    Missing semicolon                                                            
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:4:43
  
  ✘  http://eslint.org/docs/rules/semi                    Missing semicolon                                                            
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:5:77
  
  ✘  http://eslint.org/docs/rules/semi                    Missing semicolon                                                            
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:6:71
  
  ✘  https://google.com/#q=import%2Ffirst                 Import in body of module; reorder to top                                     
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:18:1
  
  ✘  https://google.com/#q=import%2Ffirst                 Import in body of module; reorder to top                                     
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:19:1

  ✘  https://google.com/#q=import%2Fnewline-after-import  Expected 1 empty line after import statement not followed by another import  
  ../../../../../multisafepay/shopware6/src/Resources/app/administration/src/main.js:19:1
  
✘ 8 problems (8 errors, 0 warnings)

Errors:
  5  http://eslint.org/docs/rules/semi
  2  https://google.com/#q=import%2Ffirst
  1  https://google.com/#q=import%2Fnewline-after-import
```

My pull request fixes these.