### PR TITLE
Use different language and addresses

### DIFF
--- a/src/Helper/CheckoutHelper.php
+++ b/src/Helper/CheckoutHelper.php
@@ -173,9 +173,15 @@ class CheckoutHelper
         Context            $context
     ): array {
         [$billingStreet, $billingHouseNumber] = $this->parseAddress($billingAddress->getStreet());
+        $contextLocale = $this->getTranslatedLocale($context);
+        $localeSeparatorIndex = \mb_strpos($contextLocale, '_');
+
+        if ($localeSeparatorIndex !== false) {
+            $contextLocale = \mb_substr($contextLocale, 0, $localeSeparatorIndex) . '_' . $this->getCountryIso($billingAddress);
+        }
 
         return [
-            'locale' => $this->getTranslatedLocale($context),
+            'locale' => $contextLocale,
             'ip_address' => $request->getClientIp(),
             'first_name' => $billingAddress->getFirstName(),
             'last_name' => $billingAddress->getLastName(),

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -18,6 +18,8 @@
             <argument type="service" id="state_machine_state.repository" />
             <argument>%kernel.shopware_version%</argument>
             <argument type="service" id="Shopware\Core\Framework\Plugin\PluginService" />
+            <argument type="service" id="locale.repository" />
+            <argument type="service" id="order_address.repository" />
         </service>
         <service id="MultiSafepay\Shopware6\Helper\MspHelper" />
         <service id="MultiSafepay\Shopware6\Helper\ApiHelper">


### PR DESCRIPTION
Sooo this is my work on supporting Visa / Carte Bancaire in my project. I have questions. First to my changes. The way how you currently access the language is only working in the unit tests as the unit tests use a mock that is too far away from the real scenario as the mock knows which locale it works with and the real scenario never sets the requests locale and therefore will always fallback to `en`. There is an other issue. Carte Bancaire is a French Visa variant and therefore needs to have the locale `fr_FR` later in the process. Even with the right locale in the request `getTranslatedLocale` will never return `fr_FR` so we still get Visa with the Generic Payment. So in this case I now use the language that has been used by the user to use the webpage. Still not perfect but more reliable.

While I dived into the code and changed the above mentioned parts I also noticed you are transfering the customers default addresses. These are very easy to access but unreliable. They are very likely to work out for persons who will rush through the checkout. Anyone who might use a new and different billing address throughout the checkout process can cause wrong data be transfered to your API. I corrected it to send the data of the order that is connected to that transaction. Be aware I made the choice to send no shipping data when no shipping information is given. This is highly unlikely but data structure from shopware allows it.

I admit, I tested it as a patch in my composer's vendor folder and it worked for me quite well. I see that I broke test code but I am unsure whether I am rewriting the tests correctly to match my changes. This is where I would like to have comments from your side.

Now I have a question reaching further out of the bounds of my change. Visa / Carte Bancaire is a French service. Why is the usage depending on a value (the locale) that is also used elsewhere in the world? So first the locale is not source I want to trust when I want to control behaviour on a regional service. Second depending on the browser request locale will definitely be different from the usage in the shop (Which presumably will enable Visa / Carte Bancaire only when billing address is France). This is very confusing to me why this approach has been used as solution and I would like to understand it a bit more as I am quite unfamiliar with branded Visa services.