### PR TITLE
Make sure GenericPaymentHandler2 and GenericPaymentHandler3 are not overwritten on update

### DIFF
--- a/src/Installers/PaymentMethodsInstaller.php
+++ b/src/Installers/PaymentMethodsInstaller.php
@@ -116,14 +116,12 @@ class PaymentMethodsInstaller implements InstallerInterface
 
         $mediaId = $this->getMediaId($paymentMethod, $context);
 
-        if (
-            $paymentMethodId !== null &&
-            (
-                $paymentMethod->getPaymentHandler() === GenericPaymentHandler::class ||
-                $paymentMethod->getPaymentHandler() === GenericPaymentHandler2::class ||
-                $paymentMethod->getPaymentHandler() === GenericPaymentHandler3::class
-            )
-        ) {
+        if ($paymentMethodId !== null
+            && in_array($paymentMethod->getPaymentHandler(), [
+                GenericPaymentHandler::class,
+                GenericPaymentHandler2::class,
+                GenericPaymentHandler3::class,
+            ])) {
             return;
         }
 

--- a/src/Installers/PaymentMethodsInstaller.php
+++ b/src/Installers/PaymentMethodsInstaller.php
@@ -6,6 +6,8 @@
 namespace MultiSafepay\Shopware6\Installers;
 
 use MultiSafepay\Shopware6\Handlers\GenericPaymentHandler;
+use MultiSafepay\Shopware6\Handlers\GenericPaymentHandler2;
+use MultiSafepay\Shopware6\Handlers\GenericPaymentHandler3;
 use MultiSafepay\Shopware6\MltisafeMultiSafepay;
 use MultiSafepay\Shopware6\PaymentMethods\IngHomePay;
 use MultiSafepay\Shopware6\PaymentMethods\MultiSafepay;
@@ -114,7 +116,14 @@ class PaymentMethodsInstaller implements InstallerInterface
 
         $mediaId = $this->getMediaId($paymentMethod, $context);
 
-        if ($paymentMethodId !== null && $paymentMethod->getPaymentHandler() === GenericPaymentHandler::class) {
+        if (
+            $paymentMethodId !== null &&
+            (
+                $paymentMethod->getPaymentHandler() === GenericPaymentHandler::class ||
+                $paymentMethod->getPaymentHandler() === GenericPaymentHandler2::class ||
+                $paymentMethod->getPaymentHandler() === GenericPaymentHandler3::class
+            )
+        ) {
             return;
         }
 


### PR DESCRIPTION
When performing an update using the command `bin/console plugin:update --no-interaction MltisafeMultiSafepay`, the title and image are reset for payment method Generic gateway 2.

Reproduction:
- Use the last version of the Multisafepay plugin
- Change the title for payment method Generic gateway 2 and add an image
- Perform a plugin update (bin/console plugin:update --no-interaction MltisafeMultiSafepay)
- Check Shopware and see the title is reset and image is missing for payment method Generic gateway 2