### PR TITLE
Update DocumentCreatedEvent.php

### DIFF
--- a/src/Subscriber/DocumentCreatedEvent.php
+++ b/src/Subscriber/DocumentCreatedEvent.php
@@ -81,7 +81,7 @@ class DocumentCreatedEvent implements EventSubscriberInterface
             foreach ($event->getWriteResults() as $writeResult) {
                 $payload = $writeResult->getPayload();
 
-                if (empty($payload) || !$this->paymentUtil->isMultiSafepayPaymentMethod($payload['orderId'], $context)) {
+                if (empty($payload) || !$this->paymentUtil->isMultiSafepayPaymentMethod($payload['orderId'] ?? $payload['id'], $context)) {
                     continue;
                 }
 


### PR DESCRIPTION
When Shopware is configured to sent mails using the queue, the payload has the orderId inside the "id" field instead of "orderId".

<img width="1513" height="744" alt="image" src="https://github.com/user-attachments/assets/dcdd1441-e555-493a-b182-6a16a34fd434" />
