### PR TITLE
Fix for sending invoice with order confirmation mail

### DIFF
--- a/src/Subscriber/DocumentCreatedEvent.php
+++ b/src/Subscriber/DocumentCreatedEvent.php
@@ -81,7 +81,9 @@ class DocumentCreatedEvent implements EventSubscriberInterface
             foreach ($event->getWriteResults() as $writeResult) {
                 $payload = $writeResult->getPayload();
 
-                if (empty($payload) || !$this->paymentUtil->isMultiSafepayPaymentMethod($payload['orderId'] ?? null, $context)) {
+                if (empty($payload) 
+                    || !isset($payload['orderId']) 
+                    || !$this->paymentUtil->isMultiSafepayPaymentMethod($payload['orderId'], $context)) {
                     continue;
                 }
 

--- a/src/Subscriber/DocumentCreatedEvent.php
+++ b/src/Subscriber/DocumentCreatedEvent.php
@@ -81,7 +81,7 @@ class DocumentCreatedEvent implements EventSubscriberInterface
             foreach ($event->getWriteResults() as $writeResult) {
                 $payload = $writeResult->getPayload();
 
-                if (empty($payload) || !$this->paymentUtil->isMultiSafepayPaymentMethod($payload['orderId'], $context)) {
+                if (empty($payload) || !$this->paymentUtil->isMultiSafepayPaymentMethod($payload['orderId'] ?? null, $context)) {
                     continue;
                 }
 


### PR DESCRIPTION
**Scenario**
In the Flowbuilder
1. Generate the invoice
2. Send the invoice with the order placed email

Then the Document.written (in DocumentCreatedEvent) is executed twice.
- First by creating the invoice
- Second when the invoice is send with the order confirm mail

Now an error is thrown because orderId is not inside the $payload.

**The problem**
When the invoice is send. The DocumentCreatedEvent is executed _again_. Because when the invoice is send, the 'send' flag is updated that the invoice was send. This also means that the $payload only contains documentId, sent flag and updatedAt date. And the orderId is missing. Therefore causing issues.

Because there is no fail-safe implemented for other Document.written scenario's, the current implementation of DocumentCreatedEvent throws exceptions and erros.

